### PR TITLE
Add example with off-screen Vulkan and Linux framebuffer display

### DIFF
--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer.sln
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ab4d.SharpEngine.Samples.LinuxFramebuffer", "Ab4d.SharpEngine.Samples.LinuxFramebuffer\Ab4d.SharpEngine.Samples.LinuxFramebuffer.csproj", "{370192F4-AE34-41A3-BE45-D4925300DA01}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{370192F4-AE34-41A3-BE45-D4925300DA01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{370192F4-AE34-41A3-BE45-D4925300DA01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{370192F4-AE34-41A3-BE45-D4925300DA01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{370192F4-AE34-41A3-BE45-D4925300DA01}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/Ab4d.SharpEngine.Samples.LinuxFramebuffer.csproj
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/Ab4d.SharpEngine.Samples.LinuxFramebuffer.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Ab4d.SharpEngine" Version="0.9.16-beta5" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0-rc.1.23419.4" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0-rc.1.23419.4" />
+      <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    </ItemGroup>
+
+</Project>

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/DrmFramebufferOutput.cs
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/DrmFramebufferOutput.cs
@@ -1,0 +1,562 @@
+/*
+ DRM/KMS framebuffer output
+ Based on double-buffered DRM/KSM example:
+ https://github.com/dvdhrm/docs/blob/master/drm-howto/modeset-double-buffered.c
+*/
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using uint16_t = System.UInt16;
+using uint32_t = System.UInt32;
+using uint64_t = System.UInt64;
+
+namespace Ab4d.SharpEngine.Samples.LinuxFramebuffer;
+
+public unsafe class DrmFramebufferOutput : OutputDevice
+{
+    private int _deviceFd = -1;
+    private Native.Drm.drmModeRes* _drmResources = null;
+    private Native.Drm.drmModeConnector* _selectedConnector;
+
+    /* Two framebuffers for double-buffered drawing */
+    private int _frontBuffer;
+    private Framebuffer ?_framebuffer1;
+    private Framebuffer ?_framebuffer2;
+
+    private Native.Drm.drmModeCrtc* _oldCrtc = null;
+
+    /* Logging */
+    private readonly ILogger? _logger;
+
+    /* Dictionary for printing connector type in human-readable form */
+    private readonly Dictionary<UInt32, string> _connectorTypeNames = new()
+    {
+        { Native.Drm.DRM_MODE_CONNECTOR_Unknown, "Unknown" },
+        { Native.Drm.DRM_MODE_CONNECTOR_VGA, "VGA" },
+        { Native.Drm.DRM_MODE_CONNECTOR_DVII, "DVI-I" },
+        { Native.Drm.DRM_MODE_CONNECTOR_DVID, "DVI-D" },
+        { Native.Drm.DRM_MODE_CONNECTOR_DVIA, "DVI-A" },
+        { Native.Drm.DRM_MODE_CONNECTOR_Composite, "Composite" },
+        { Native.Drm.DRM_MODE_CONNECTOR_SVIDEO, "S-VIDEO" },
+        { Native.Drm.DRM_MODE_CONNECTOR_LVDS, "LVDS" },
+        { Native.Drm.DRM_MODE_CONNECTOR_Component, "Component" },
+        { Native.Drm.DRM_MODE_CONNECTOR_9PinDIN, "9-Pin DIN" },
+        { Native.Drm.DRM_MODE_CONNECTOR_DisplayPort, "DisplayPort" },
+        { Native.Drm.DRM_MODE_CONNECTOR_HDMIA, "HDMI-A" },
+        { Native.Drm.DRM_MODE_CONNECTOR_HDMIB, "HDMI-B" },
+        { Native.Drm.DRM_MODE_CONNECTOR_TV, "TV" },
+        { Native.Drm.DRM_MODE_CONNECTOR_eDP, "eDP" },
+        { Native.Drm.DRM_MODE_CONNECTOR_VIRTUAL, "VIRTUAL" },
+        { Native.Drm.DRM_MODE_CONNECTOR_DSI, "DSI" },
+        { Native.Drm.DRM_MODE_CONNECTOR_DPI, "DPI" },
+        { Native.Drm.DRM_MODE_CONNECTOR_WRITEBACK, "WRITEBACK" },
+        { Native.Drm.DRM_MODE_CONNECTOR_SPI, "SPI" },
+        { Native.Drm.DRM_MODE_CONNECTOR_USB, "USB" },
+    };
+
+    public static string? FindFirstDevice()
+    {
+        var files = Directory.GetFiles("/dev/dri");
+        Array.Sort(files);
+        foreach (var file in files)
+        {
+            var match = Regex.Match(file, "card[0-9]+");
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var fd = Native.LibC.open(file, Native.LibC.O_RDWR | Native.LibC.O_CLOEXEC, 0);
+            if (fd == -1)
+            {
+                continue;
+            }
+
+            Native.LibC.close(fd);
+            return file;
+        }
+
+        return null;
+    }
+
+    public DrmFramebufferOutput(ILoggerFactory? loggerFactory = null)
+    {
+        _logger = loggerFactory?.CreateLogger<DrmFramebufferOutput>();
+    }
+
+    public override void Initialize(string deviceName, int requestedWidth, int requestedHeight)
+    {
+        /* Open DRM device */
+        _deviceFd = Native.LibC.open(deviceName, Native.LibC.O_RDWR | Native.LibC.O_CLOEXEC, 0);
+        if (_deviceFd <= 0)
+        {
+            Cleanup();
+            throw new Exception($"Failed to open DRI device {deviceName}: {Marshal.GetLastWin32Error()}");
+        }
+
+        /* Ensure that device supports dumb buffers */
+        UInt64 supportsDumpBuffers = 0;
+        if (Native.Drm.drmGetCap(_deviceFd, Native.Drm.DRM_CAP_DUMB_BUFFER, &supportsDumpBuffers) < 0 ||
+            supportsDumpBuffers == 0)
+        {
+            Cleanup();
+            throw new Exception($"Device does not support dumb buffers for framebuffer mapping!");
+        }
+
+        /* Query the DRM resources */
+        _drmResources = Native.Drm.drmModeGetResources(_deviceFd);
+        if (_drmResources is null)
+        {
+            Cleanup();
+            throw new Exception($"Failed to query DRM resources on  device: {Marshal.GetLastWin32Error()}");
+        }
+
+        _logger?.LogInformation("DRM resources on device:");
+        _logger?.LogInformation(" - framebuffers: {count}", _drmResources->count_fbs);
+        _logger?.LogInformation(" - CRTCs: {count}", _drmResources->count_crtcs);
+        _logger?.LogInformation(" - connectors: {count}", _drmResources->count_connectors);
+        _logger?.LogInformation(" - encoders: {count}", _drmResources->count_encoders);
+
+        /* Display available connectors info */
+        _logger?.LogInformation("Available connectors:");
+        for (var i = 0; i < _drmResources->count_connectors; i++)
+        {
+            var connector = Native.Drm.drmModeGetConnectorCurrent(_deviceFd, _drmResources->connectors[i]);
+            if (connector is null)
+            {
+                continue;
+            }
+
+            _connectorTypeNames.TryGetValue(connector->connector_type, out var connectorTypeName);
+            _logger?.LogInformation("  {type} #{number}: {state}",
+                connectorTypeName ?? "<UNKNOWN>", connector->connector_type_id, connector->connection);
+            Native.Drm.drmModeFreeConnector(connector);
+        }
+
+        /* Pick the first connected connector */
+        _selectedConnector = null;
+        for (var i = 0; i < _drmResources->count_connectors; i++)
+        {
+            var connector = Native.Drm.drmModeGetConnectorCurrent(_deviceFd, _drmResources->connectors[i]);
+            if (connector is null)
+            {
+                continue;
+            }
+
+            if (connector->connection == Native.Drm.drmModeConnection.DRM_MODE_CONNECTED)
+            {
+                _selectedConnector = connector;
+                break;
+            }
+
+            Native.Drm.drmModeFreeConnector(connector);
+        }
+
+        if (_selectedConnector == null)
+        {
+            Cleanup();
+            throw new Exception("No connected connectors found!");
+        }
+
+        _connectorTypeNames.TryGetValue(_selectedConnector->connector_type, out var connectorType);
+        _logger?.LogInformation("Using connector: {type} #{number} ({state})",
+            connectorType ?? "<UNKNOWN>", _selectedConnector->connector_type_id, _selectedConnector->connection);
+
+        /* Dump all modes */
+        _logger?.LogInformation("Available modes ({count}):", _selectedConnector->count_modes);
+        for (var i = 0; i < _selectedConnector->count_modes; i++)
+        {
+            var mode = &_selectedConnector->modes[i];
+            _logger?.LogInformation(" - mode: {width}x{height}@{refresh}", mode->hdisplay, mode->vdisplay, mode->vrefresh);
+        }
+
+        /* Select mode (resolution) */
+        Native.Drm.drmModeModeInfo* selectedMode = null;
+        if (requestedWidth != 0 || requestedHeight != 0)
+        {
+            /* Find the mode with compatible resolution */
+            for (var i = 0; i < _selectedConnector->count_modes; i++)
+            {
+                var mode = &_selectedConnector->modes[i];
+                if (requestedWidth != 0 && requestedWidth != mode->hdisplay)
+                {
+                    continue;
+                }
+                if (requestedHeight != 0 && requestedHeight != mode->vdisplay)
+                {
+                    continue;
+                }
+
+                /* We found compatible mode */
+                selectedMode = mode;
+                break;
+            }
+
+            if (selectedMode == null)
+            {
+                Cleanup();
+                throw new Exception($"Could not find requested mode: {requestedWidth}x{requestedHeight}!");
+            }
+        } else {
+            /* Find preferred mode */
+            for (var i = 0; i < _selectedConnector->count_modes; i++)
+            {
+                var mode = &_selectedConnector->modes[i];
+                if ((mode->type & Native.Drm.DRM_MODE_TYPE_PREFERRED) != 0)
+                {
+                    selectedMode = mode;
+                    break;
+                }
+            }
+
+            if (selectedMode == null)
+            {
+                Cleanup();
+                throw new Exception("Could not find preferred mode for connector!");
+            }
+        }
+
+        _logger?.LogInformation("Using mode: {width}x{height}@{refresh}", selectedMode->hdisplay, selectedMode->vdisplay, selectedMode->vrefresh);
+
+        ScreenWidth = selectedMode->hdisplay;
+        ScreenHeight = selectedMode->vdisplay;
+        RgbaMode = false; /* BGRA */
+
+        /* Find encoder and CRTC combination */
+        var crtcId = FindCompatibleCrtc();
+        if (crtcId == 0)
+        {
+            Cleanup();
+            throw new Exception("Failed to find suitable CRTC for connector!");
+        }
+
+        /* Create dumb buffers */
+        try
+        {
+            _framebuffer1 = new Framebuffer(
+                _deviceFd,
+                ScreenWidth,
+                ScreenHeight,
+                crtcId,
+                _selectedConnector->connector_id,
+                *selectedMode);
+        }
+        catch (Exception)
+        {
+            Cleanup();
+            throw;
+        }
+
+        try
+        {
+            _framebuffer2 = new Framebuffer(
+                _deviceFd,
+                ScreenWidth,
+                ScreenHeight,
+                crtcId,
+                _selectedConnector->connector_id,
+                *selectedMode);
+        }
+        catch (Exception)
+        {
+            Cleanup();
+            throw;
+        }
+
+        /* Store currently set CRTC... */
+        _oldCrtc = Native.Drm.drmModeGetCrtc(_deviceFd, crtcId);
+        /* ... and perform a buffer flip to force initial mode-set */
+        _frontBuffer = 0;
+        try
+        {
+            _framebuffer1.FillAndActivate(null);
+        }
+        catch (Exception e)
+        {
+            throw new Exception("Failed to perform initial mode-set", e);
+        }
+    }
+
+    private UInt32 FindCompatibleCrtc()
+    {
+        Native.Drm.drmModeEncoder* encoder = null;
+        UInt32 crtcId = 0;
+
+        /* First, try the currently connected encoder + CRTC */
+        if (_selectedConnector->encoder_id != 0)
+        {
+            encoder = Native.Drm.drmModeGetEncoder(_deviceFd, _selectedConnector->encoder_id);
+        }
+
+        if (encoder != null)
+        {
+            crtcId = encoder->crtc_id;
+            Native.Drm.drmModeFreeEncoder(encoder);
+        }
+
+        if (crtcId != 0)
+        {
+            _logger?.LogInformation("Found an existing valid encoder + CRTC combination.");
+            return crtcId;
+        }
+
+        /* If the connector is not currently bound to an encoder, iterate all other available encoders to find a matching CRTC. */
+        for (var i = 0; i < _selectedConnector->count_encoders; i++)
+        {
+            encoder = Native.Drm.drmModeGetEncoder(_deviceFd, _selectedConnector->encoders[i]);
+            if (encoder == null)
+            {
+                _logger?.LogWarning("Failed to retrieve encoder #{number}: {id}! Errno: {errno}",
+                    i, _selectedConnector->encoders[i], Marshal.GetLastWin32Error());
+                continue;
+            }
+
+            /* Iterate over all global CRTCs */
+            for (var j = 0; j < _drmResources->count_crtcs; j++)
+            {
+                /* Check if this CRTC works with the encoder */
+                if ((encoder->possible_crtcs & (1 << j)) == 0)
+                {
+                    continue;
+                }
+
+                /* Use first compatible CRTC */
+                crtcId = _drmResources->crtcs[j];
+                _logger?.LogInformation("Found compatible encoder {encoderId} and CRTC {crtcId}.", encoder->encoder_id, crtcId);
+                break;
+            }
+
+            Native.Drm.drmModeFreeEncoder(encoder);
+
+            if (crtcId != 0)
+            {
+                break;
+            }
+        }
+
+        return crtcId;
+    }
+
+    public override void DisplayImageData(byte *data)
+    {
+        var backBuffer = _frontBuffer == 0 ? _framebuffer2 : _framebuffer1;
+        Debug.Assert(backBuffer != null, nameof(backBuffer) + " != null");
+        backBuffer.FillAndActivate(data);
+        _frontBuffer = (_frontBuffer + 1) % 2;
+    }
+
+    public override void Cleanup()
+    {
+        /* Restore old CRTC, if available */
+        if (_oldCrtc != null)
+        {
+            _logger?.LogInformation("Restoring old CRTC...");
+            Native.Drm.drmModeSetCrtc(
+                _deviceFd,
+                _oldCrtc->crtc_id,
+                _oldCrtc->buffer_id,
+                _oldCrtc->x,
+                _oldCrtc->y,
+                &_selectedConnector->connector_id,
+                1,
+                &_oldCrtc->mode);
+            Native.Drm.drmModeFreeCrtc(_oldCrtc);
+            _oldCrtc = null;
+        }
+
+        /* Free framebuffers */
+        if (_framebuffer1 != null)
+        {
+            _logger?.LogInformation("Freeing framebuffer #1...");
+            _framebuffer1.Cleanup();
+            _framebuffer1 = null;
+        }
+
+        if (_framebuffer2 != null)
+        {
+            _logger?.LogInformation("Freeing framebuffer #2...");
+            _framebuffer2.Cleanup();
+            _framebuffer2 = null;
+        }
+
+        /* Free connector data */
+        if (_selectedConnector != null)
+        {
+            Native.Drm.drmModeFreeConnector(_selectedConnector);
+            _selectedConnector = null;
+        }
+
+        /* Free resources data */
+        if (_drmResources != null)
+        {
+            Native.Drm.drmModeFreeResources(_drmResources);
+            _drmResources = null;
+        }
+
+        /* Close DRM device */
+        if (_deviceFd >= 0)
+        {
+            if (Native.LibC.close(_deviceFd) < 0)
+            {
+                throw new Exception($"$Failed to close device file descriptor: {Marshal.GetLastWin32Error()}");
+            }
+            _deviceFd = -1;
+        }
+    }
+
+    class Framebuffer
+    {
+        /* Device and its resolution */
+        private readonly int _deviceFd;
+        private readonly uint32_t _width;
+        private readonly uint32_t _height;
+
+        private readonly uint32_t _crtcId;
+        private readonly uint32_t _connectorId;
+        private readonly Native.Drm.drmModeModeInfo _modeInfo;
+
+        /* Dumb buffer */
+        private bool _dumbBufferCreated;
+        private uint32_t _stride;
+        private uint64_t _size;
+        private uint32_t _handle;
+
+        private IntPtr _bufferAddress;
+
+        /* Framebuffer */
+        private bool _framebufferCreated;
+        private uint32_t _framebufferId;
+
+        public Framebuffer(
+            int deviceFd,
+            int width,
+            int height,
+            uint32_t crtcId,
+            uint32_t connectorId,
+            Native.Drm.drmModeModeInfo modeInfo)
+        {
+            _deviceFd = deviceFd;
+            _width = (uint32_t)width;
+            _height = (uint32_t)height;
+
+            _crtcId = crtcId;
+            _connectorId = connectorId;
+
+            _modeInfo = modeInfo;
+
+            Initialize();
+        }
+
+        public void FillAndActivate(byte *data)
+        {
+            /* Copy data */
+            if (data != null)
+            {
+                Unsafe.CopyBlock((byte *)_bufferAddress, data, (uint)_size);
+            }
+
+            /* Activate buffer by setting CRTC */
+            fixed (uint32_t* connectorIdPtr = &_connectorId)
+            {
+                fixed (Native.Drm.drmModeModeInfo* modeInfoPtr = &_modeInfo)
+                {
+                    var ret = Native.Drm.drmModeSetCrtc(_deviceFd, _crtcId, _framebufferId, 0, 0, connectorIdPtr, 1,
+                        modeInfoPtr);
+                    if (ret < 0)
+                    {
+                        throw new Exception("Failed to set CRTC.");
+                    }
+                }
+            }
+        }
+
+        private void Initialize()
+        {
+            /* Create dumb buffer */
+            var createRequest = new Native.Drm.drm_mode_create_dumb
+            {
+                width = _width,
+                height = _height,
+                bpp = 32
+            };
+            var ret = Native.Drm.drmIoctl(_deviceFd, Native.Drm.DRM_IOCTL_MODE_CREATE_DUMB, &createRequest);
+            if (ret < 0)
+            {
+                Cleanup();
+                throw new Exception($"Failed to create dumb buffer: {Marshal.GetLastWin32Error()}");
+            }
+
+            _stride = createRequest.pitch;
+            _size = createRequest.size;
+            _handle = createRequest.handle;
+
+            _dumbBufferCreated = true;
+
+            /* Create framebuffer object for the dumb-buffer */
+            ret = Native.Drm.drmModeAddFB(_deviceFd, _width, _height, 24, 32, _stride, _handle, out _framebufferId);
+            if (ret < 0)
+            {
+                Cleanup();
+                throw new Exception($"Failed to create framebuffer for dumb buffer: {Marshal.GetLastWin32Error()}");
+            }
+
+            _framebufferCreated = true;
+
+            /* Prepare buffer for mapping */
+            var mapRequest = new Native.Drm.drm_mode_map_dumb
+            {
+                handle = _handle
+            };
+            ret = Native.Drm.drmIoctl(_deviceFd, Native.Drm.DRM_IOCTL_MODE_MAP_DUMB, &mapRequest);
+            if (ret < 0)
+            {
+                Cleanup();
+                throw new Exception($"Failed to prepare dumb buffer for mapping: {Marshal.GetLastWin32Error()}");
+            }
+
+            /* Perform actual memory mapping */
+            _bufferAddress = Native.LibC.mmap(
+                IntPtr.Zero,
+                (IntPtr)_size,
+                Native.LibC.PROT_READ | Native.LibC.PROT_WRITE,
+                Native.LibC.MAP_SHARED,
+                _deviceFd, (IntPtr)mapRequest.offset);
+            if (_bufferAddress == (IntPtr)(-1))
+            {
+                Cleanup();
+                throw new Exception($"Failed to mmap dumb buffer: {Marshal.GetLastWin32Error()}");
+            }
+
+            /* Clear the framebuffer */
+            Native.LibC.memset(_bufferAddress, 0, (IntPtr)_size);
+        }
+
+        public void Cleanup()
+        {
+            /* Unmap buffer */
+            if (_bufferAddress != (IntPtr)(-1))
+            {
+                Native.LibC.munmap(_bufferAddress, (IntPtr)_size);
+            }
+
+            /* Destroy framebuffer */
+            if (_framebufferCreated)
+            {
+                Native.Drm.drmModeRmFB(_deviceFd, _framebufferId);
+            }
+
+            /* Destroy dumb buffer */
+            if (_dumbBufferCreated)
+            {
+                var destroyReq = new Native.Drm.drm_mode_destroy_dumb
+                {
+                    handle = _handle
+                };
+                Native.Drm.drmIoctl(_deviceFd, Native.Drm.DRM_IOCTL_MODE_DESTROY_DUMB, &destroyReq);
+            }
+        }
+    }
+}

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/FbDevOutput.cs
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/FbDevOutput.cs
@@ -1,0 +1,161 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+namespace Ab4d.SharpEngine.Samples.LinuxFramebuffer;
+
+public class FbDevOutput : OutputDevice
+{
+    private int _deviceFd = -1;
+
+    private int _framebufferSize;
+    private IntPtr _framebufferAddress = new(-1);
+
+    /* Logging */
+    private readonly ILogger? _logger;
+
+    public static string? FindFirstDevice()
+    {
+        var files = Directory.GetFiles("/dev");
+        Array.Sort(files);
+        foreach(var file in files)
+        {
+            var match = Regex.Match(file, "fb[0-9]+");
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var fd = Native.LibC.open(file, Native.LibC.O_RDWR | Native.LibC.O_CLOEXEC, 0);
+            if (fd == -1)
+            {
+                continue;
+            }
+
+            Native.LibC.close(fd);
+            return file;
+        }
+
+        return null;
+    }
+
+    public FbDevOutput(ILoggerFactory? loggerFactory = null)
+    {
+        _logger = loggerFactory?.CreateLogger<FbDevOutput>();
+    }
+
+    public override unsafe void Initialize(string deviceName, int requestedWidth, int requestedHeight)
+    {
+        /* This backend does not support requested width/height */
+        if (requestedWidth != 0 || requestedHeight != 0)
+        {
+            throw new Exception("FdDev output does not support screen size request.");
+        }
+
+        /* Open framebuffer device */
+        _deviceFd = Native.LibC.open(deviceName, Native.LibC.O_RDWR | Native.LibC.O_CLOEXEC, 0);
+        if (_deviceFd <= 0)
+        {
+            Cleanup();
+            throw new Exception($"Failed to open framebuffer device {deviceName}: {Marshal.GetLastWin32Error()}");
+        }
+
+        /* Query the screen information */
+        var screenInfo = new Native.FbDev.fb_var_screeninfo();
+        if (Native.LibC.ioctl(_deviceFd, Native.FbDev.FBIOGET_VSCREENINFO, &screenInfo) < 0)
+        {
+            Cleanup();
+            throw new Exception($"Failed to query screen info: {Marshal.GetLastWin32Error()}");
+        }
+
+        /* Validate framebuffer mode */
+        _logger?.LogInformation("Framebuffer depth: {depth} bits per pixel", screenInfo.bits_per_pixel);
+        if (screenInfo.bits_per_pixel != 32)
+        {
+            Cleanup();
+            throw new Exception($"Unsupported bit depth: {screenInfo.bits_per_pixel}! Only 32 BPP is supported!");
+        }
+
+        if (screenInfo.red.length == 8 && screenInfo.green.length == 8 && screenInfo.blue.length == 8 &&
+            (screenInfo.transp.length == 8 || screenInfo.transp.length == 0))
+        {
+            if (screenInfo.red.offset == 0 && screenInfo.green.offset == 8 && screenInfo.blue.offset == 16 &&
+                (screenInfo.transp.offset == 24 || screenInfo.transp.offset == 0))
+            {
+                _logger?.LogInformation("Framebuffer color mode: RGBA8888");
+                RgbaMode = true;
+            }
+            else if (screenInfo.red.offset == 16 && screenInfo.green.offset == 8 && screenInfo.blue.offset == 0 &&
+                     (screenInfo.transp.offset == 24 || screenInfo.transp.offset == 0))
+            {
+                _logger?.LogInformation("Framebuffer color mode: BGRA8888");
+                RgbaMode = false;
+            }
+            else
+            {
+                Cleanup();
+                throw new Exception(
+                    $"Unsupported color mode! Only RGBA8888 and BGRA8888 are supported! Offsets: " +
+                    $"R={screenInfo.red.offset} G={screenInfo.green.offset} B={screenInfo.blue.offset} A={screenInfo.transp.offset}");
+            }
+        }
+        else
+        {
+            Cleanup();
+            throw new Exception(
+                $"Unsupported bit depth: only RGBA8888 and BGRA8888 are supported! Depths: " +
+                $"R={screenInfo.red.length} G={screenInfo.green.length} B={screenInfo.blue.length} A={screenInfo.transp.length}");
+        }
+
+        /* Map the framebuffer */
+        ScreenWidth = (int)screenInfo.xres;
+        ScreenHeight = (int)screenInfo.yres;
+        _logger?.LogInformation("Screen dimensions: {width} x {height}", ScreenWidth, ScreenHeight);
+
+        var bytesPerRow = screenInfo.xres * screenInfo.bits_per_pixel / 8;
+        _framebufferSize = (int)(screenInfo.yres * bytesPerRow);
+
+        _framebufferAddress = Native.LibC.mmap(
+            IntPtr.Zero,
+            new IntPtr(_framebufferSize),
+            Native.LibC.PROT_READ | Native.LibC.PROT_WRITE,
+            Native.LibC.MAP_SHARED,
+            _deviceFd,
+            IntPtr.Zero);
+        if (_framebufferAddress == new IntPtr(-1))
+        {
+            throw new Exception($"Failed to mmap framebuffer: {Marshal.GetLastWin32Error()}");
+        }
+    }
+
+    public override unsafe void DisplayImageData(byte *data)
+    {
+        /* Copy on vsync */
+        Native.LibC.ioctl(_deviceFd, Native.FbDev.FBIO_WAITFORVSYNC, null);
+        Unsafe.CopyBlock((byte *)_framebufferAddress, data, (uint)_framebufferSize); /* in lieu of memcpy() */
+    }
+
+    public override void Cleanup()
+    {
+        /* Unmap framebuffer */
+        if (_framebufferAddress != new IntPtr(-1))
+        {
+            if (Native.LibC.munmap(_framebufferAddress, new IntPtr(_framebufferSize)) < 0)
+            {
+                throw new Exception($"Failed to munmap framebuffer: {Marshal.GetLastWin32Error()}");
+            }
+            _framebufferAddress = new IntPtr(-1);
+        }
+
+        /* Close framebuffer device */
+        if (_deviceFd >= 0)
+        {
+            if (Native.LibC.close(_deviceFd) < 0)
+            {
+                throw new Exception($"$Failed to close framebuffer file descriptor: {Marshal.GetLastWin32Error()}");
+            }
+            _deviceFd = -1;
+        }
+    }
+}

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/InputDevice.cs
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/InputDevice.cs
@@ -1,0 +1,243 @@
+/*
+ * libInput keyboard/mouse processing
+ * Based on example from:
+ * https://github.com/eyelash/tutorials/blob/master/libinput.c
+ */
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace Ab4d.SharpEngine.Samples.LinuxFramebuffer;
+
+public unsafe class InputDevice
+{
+    private Native.Udev.udev* _udev;
+    private Native.LibInput.libinput* _libinput;
+
+    private IntPtr* _libinputIoIface;
+
+    private Native.Xkbc.xkb_state *_xkbState;
+    private Native.Xkbc.xkb_keymap *_xkbKeymap;
+    private Native.Xkbc.xkb_context *_xkbContext;
+
+    private readonly int _screenWidth;
+    private readonly int _screenHeight;
+
+    private bool _isRunning;
+    private Thread? _inputThread;
+
+    public double MousePointerX;
+    public double MousePointerY;
+
+    /* Logging */
+    private readonly ILogger? _logger;
+
+    /* Keyboard event signalling */
+    public class KeyPressEventArgs : EventArgs
+    {
+        public uint KeyCode { get; set; }
+    }
+    public event EventHandler? KeyPressEventHandler;
+
+    public InputDevice(int screenWidth, int screenHeight, string seatName = "seat0", ILoggerFactory ?loggerFactory = null)
+    {
+        _screenWidth = screenWidth;
+        _screenHeight = screenHeight;
+
+        /* Logger */
+        _logger = loggerFactory?.CreateLogger<InputDevice>();
+
+        /* Create udev instance */
+        _udev = Native.Udev.udev_new();
+        if (_udev == null)
+        {
+            Cleanup();
+            throw new Exception("Failed to create udev!");
+        }
+
+        /* Create libinput instance */
+        _libinputIoIface = (IntPtr*)Marshal.AllocHGlobal(IntPtr.Size * 2);
+        _libinputIoIface[0] = Marshal.GetFunctionPointerForDelegate<Native.LibInput.OpenRestrictedCallbackDelegate>(
+            (path, flags, _) => Native.LibC.open(path, flags, 0));
+        _libinputIoIface[1] = Marshal.GetFunctionPointerForDelegate<Native.LibInput.CloseRestrictedCallbackDelegate>(
+            (fd, _) => Native.LibC.close(fd));
+
+        _libinput = Native.LibInput.libinput_udev_create_context(_libinputIoIface, null, _udev);
+
+        if (_libinput == null)
+        {
+            Cleanup();
+            throw new Exception("Failed to create libinput!");
+        }
+
+        /* Assign seat */
+        if (Native.LibInput.libinput_udev_assign_seat(_libinput, seatName) == -1)
+        {
+            Cleanup();
+            throw new Exception("Failed to assign libinput seat!");
+        }
+
+        /* Create XKB context and state */
+        _xkbContext = Native.Xkbc.xkb_context_new(Native.Xkbc.XKB_CONTEXT_NO_FLAGS);
+        _xkbKeymap = Native.Xkbc.xkb_keymap_new_from_names(
+            _xkbContext,
+            null,
+            Native.Xkbc.XKB_KEYMAP_COMPILE_NO_FLAGS);
+        if (_xkbKeymap == null)
+        {
+            Cleanup();
+            throw new Exception("Failed to load keymap!");
+        }
+        _xkbState = Native.Xkbc.xkb_state_new(_xkbKeymap);
+
+        /* Start the input event processing thread */
+        _isRunning = true;
+        _inputThread = new Thread(InputMainLoop);
+        _inputThread.Start();
+    }
+
+    public void Cleanup()
+    {
+        /* Stop the input event processing thread */
+        if (_inputThread != null)
+        {
+            /* Signal the loop in thread function to stop, then wait for thread itself to stop */
+            _isRunning = false;
+            _inputThread.Join();
+            _inputThread = null;
+        }
+
+        /* Free XKB */
+        if (_xkbState != null)
+        {
+            Native.Xkbc.xkb_state_unref(_xkbState);
+            _xkbState = null;
+        }
+
+        if (_xkbKeymap != null)
+        {
+            Native.Xkbc.xkb_keymap_unref(_xkbKeymap);
+            _xkbKeymap = null;
+        }
+
+        if (_xkbContext != null)
+        {
+            Native.Xkbc.xkb_context_unref(_xkbContext);
+            _xkbContext = null;
+        }
+
+        /* Free libinput */
+        if (_libinput != null)
+        {
+            Native.LibInput.libinput_unref(_libinput);
+            _libinput = null;
+        }
+
+        if (_libinputIoIface != null)
+        {
+            Marshal.FreeHGlobal((IntPtr)_libinputIoIface);
+            _libinputIoIface = null;
+        }
+
+        /* Free udev */
+        if (_udev != null)
+        {
+            Native.Udev.udev_unref(_udev);
+            _udev = null;
+        }
+    }
+
+
+    private void InputMainLoop()
+    {
+        Native.LibC.pollfd pollFd = new()
+        {
+            fd = Native.LibInput.libinput_get_fd(_libinput),
+            events = Native.LibC.POLLIN,
+            revents = 0
+        };
+
+        while (_isRunning)
+        {
+            /* Poll for events */
+            if (Native.LibC.poll(&pollFd, (IntPtr)1, 10) < 0)
+            {
+                _logger?.LogWarning("Polling for events failed!");
+                continue;
+            }
+
+            /* Dispatch */
+            if (Native.LibInput.libinput_dispatch(_libinput) < 0)
+            {
+                _logger?.LogWarning("Event dispatch failed!");
+                continue;
+            }
+
+            /* Process events */
+            Native.LibInput.libinput_event* evt;
+            while ((evt = Native.LibInput.libinput_get_event(_libinput)) != null)
+            {
+
+                var type = Native.LibInput.libinput_event_get_type(evt);
+                _logger?.LogDebug("Received event of type {type}", type);
+
+                if (type == Native.LibInput.LIBINPUT_EVENT_POINTER_MOTION)
+                {
+                    var dx = Native.LibInput.libinput_event_pointer_get_dx(evt);
+                    var dy = Native.LibInput.libinput_event_pointer_get_dy(evt);
+                    _logger?.LogDebug("Pointer motion event: {x}, {y}", dx, dy);
+                    MousePointerX += dx;
+                    MousePointerY += dy;
+
+                    /* Clamp */
+                    MousePointerX = Math.Max(Math.Min(MousePointerX, _screenWidth), 0.0);
+                    MousePointerY = Math.Max(Math.Min(MousePointerY, _screenHeight), 0.0);
+                }
+                if (type == Native.LibInput.LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE)
+                {
+                    MousePointerX =
+                        Native.LibInput.libinput_event_pointer_get_absolute_x_transformed(evt, (uint)_screenWidth);
+                    MousePointerY =
+                        Native.LibInput.libinput_event_pointer_get_absolute_y_transformed(evt, (uint)_screenHeight);
+                    _logger?.LogDebug("Pointer absolute motion event: {x:F0}, {y:F0}", MousePointerX, MousePointerY);
+                }
+                else if (type == Native.LibInput.LIBINPUT_EVENT_POINTER_BUTTON)
+                {
+                    _logger?.LogDebug("Pointer button event");
+                }
+                else if (type == Native.LibInput.LIBINPUT_EVENT_KEYBOARD_KEY)
+                {
+                    var key = Native.LibInput.libinput_event_keyboard_get_key(evt);
+                    var state = Native.LibInput.libinput_event_keyboard_get_key_state(evt);
+                    _logger?.LogDebug("Keyboard event: key={key}, state={state}", key, state);
+
+                    /* Update XKB state */
+                    Native.Xkbc.xkb_state_update_key(_xkbState, key + 8, state);
+                    if (state == Native.LibInput.LIBINPUT_KEY_STATE_PRESSED)
+                    {
+                        var utf32 = Native.Xkbc.xkb_state_key_get_utf32(_xkbState, key + 8);
+                        if (utf32 != 0)
+                        {
+                            if (utf32 is >= 0x21 and <= 0x7E)
+                            {
+                                _logger?.LogInformation("The key {char} was pressed.", (char)utf32);
+                            }
+                            else
+                            {
+                                _logger?.LogInformation("The key U+{code:X4} was pressed.", utf32);
+                            }
+
+                            /* Fire the event */
+                            KeyPressEventHandler?.Invoke(this, new KeyPressEventArgs()
+                            {
+                                KeyCode = utf32
+                            });
+                        }
+                    }
+                }
+
+                Native.LibInput.libinput_event_destroy(evt);
+            }
+        }
+    }
+}

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/NativeDrm.cs
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/NativeDrm.cs
@@ -1,0 +1,228 @@
+using System.Runtime.InteropServices;
+using uint8_t = System.Byte;
+using uint16_t = System.UInt16;
+using uint32_t = System.UInt32;
+using uint64_t = System.UInt64;
+
+using __u16 = System.UInt16;
+using __u32 = System.UInt32;
+using __u64 = System.UInt64;
+
+namespace Ab4d.SharpEngine.Samples.LinuxFramebuffer;
+
+public static partial class Native
+{
+    public static unsafe class Drm
+    {
+        private const string LibName = "libdrm.so.2";
+
+        /* Functions from libdrm */
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int drmGetCap(int fd, uint64_t capability, uint64_t* value);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern drmModeRes* drmModeGetResources(int fd);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern void drmModeFreeResources(drmModeRes *ptr);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern drmModeConnector* drmModeGetConnectorCurrent(int fd, uint32_t connector_id);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern void drmModeFreeConnector(drmModeConnector *ptr);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern drmModeEncoder *drmModeGetEncoder(int fd, uint32_t encoder_id);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern void drmModeFreeEncoder(drmModeEncoder *ptr);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern drmModeCrtc *drmModeGetCrtc(int fd, uint32_t crtc_id);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern void drmModeFreeCrtc(drmModeCrtc *ptr);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int drmIoctl(int fd, ulong request, void *arg);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int drmModeAddFB(int fd, uint32_t width, uint32_t height, uint8_t depth, uint8_t bpp,
+            uint32_t pitch, uint32_t bo_handle, out uint32_t buf_id);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int drmModeRmFB(int fd, uint32_t fb_id);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int drmModeSetCrtc(int fd, uint32_t crtc_id, uint32_t fb_id, uint32_t x, uint32_t y, uint32_t *connectors, int count, drmModeModeInfo *drm_mode);
+
+        /* ioctl() constants */
+        public const uint32_t DRM_IOCTL_MODE_CREATE_DUMB = 0xC02064B2;
+        public const uint32_t DRM_IOCTL_MODE_MAP_DUMB = 0xC01064B3;
+        public const uint32_t DRM_IOCTL_MODE_DESTROY_DUMB = 0xC00464B4;
+
+        /* DRM structures */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct drmModeRes
+        {
+            public int count_fbs;
+            public uint32_t *fbs;
+
+            public int count_crtcs;
+            public uint32_t *crtcs;
+
+            public int count_connectors;
+            public uint32_t *connectors;
+
+            public int count_encoders;
+            public uint32_t *encoders;
+
+            public uint32_t min_width, max_width;
+            public uint32_t min_height, max_height;
+        }
+
+        public enum drmModeConnection
+        {
+            DRM_MODE_CONNECTED = 1,
+            DRM_MODE_DISCONNECTED = 2,
+            DRM_MODE_UNKNOWNCONNECTION = 3
+        }
+
+        public enum drmModeSubPixel
+        {
+            DRM_MODE_SUBPIXEL_UNKNOWN = 1,
+            DRM_MODE_SUBPIXEL_HORIZONTAL_RGB = 2,
+            DRM_MODE_SUBPIXEL_HORIZONTAL_BGR = 3,
+            DRM_MODE_SUBPIXEL_VERTICAL_RGB = 4,
+            DRM_MODE_SUBPIXEL_VERTICAL_BGR = 5,
+            DRM_MODE_SUBPIXEL_NONE = 6
+        }
+
+        /* Mode types */
+        public const uint32_t DRM_MODE_TYPE_BUILTIN = 1 << 0;
+        public const uint32_t DRM_MODE_TYPE_CLOCK_C = (1 << 1) | DRM_MODE_TYPE_BUILTIN;
+        public const uint32_t DRM_MODE_TYPE_CRTC_C = (1 << 2) | DRM_MODE_TYPE_BUILTIN;
+        public const uint32_t DRM_MODE_TYPE_PREFERRED = 1 << 3;
+        public const uint32_t DRM_MODE_TYPE_DEFAULT = 1 << 4;
+        public const uint32_t DRM_MODE_TYPE_USERDEF = 1 << 5;
+        public const uint32_t DRM_MODE_TYPE_DRIVER = 1 << 6;
+
+        /* Connector type IDs */
+        public const uint32_t DRM_MODE_CONNECTOR_Unknown = 0;
+        public const uint32_t DRM_MODE_CONNECTOR_VGA = 1;
+        public const uint32_t DRM_MODE_CONNECTOR_DVII = 2;
+        public const uint32_t DRM_MODE_CONNECTOR_DVID = 3;
+        public const uint32_t DRM_MODE_CONNECTOR_DVIA = 4;
+        public const uint32_t DRM_MODE_CONNECTOR_Composite = 5;
+        public const uint32_t DRM_MODE_CONNECTOR_SVIDEO = 6;
+        public const uint32_t DRM_MODE_CONNECTOR_LVDS = 7;
+        public const uint32_t DRM_MODE_CONNECTOR_Component = 8;
+        public const uint32_t DRM_MODE_CONNECTOR_9PinDIN = 9;
+        public const uint32_t DRM_MODE_CONNECTOR_DisplayPort = 10;
+        public const uint32_t DRM_MODE_CONNECTOR_HDMIA = 11;
+        public const uint32_t DRM_MODE_CONNECTOR_HDMIB = 12;
+        public const uint32_t DRM_MODE_CONNECTOR_TV = 13;
+        public const uint32_t DRM_MODE_CONNECTOR_eDP = 14;
+        public const uint32_t DRM_MODE_CONNECTOR_VIRTUAL = 15;
+        public const uint32_t DRM_MODE_CONNECTOR_DSI = 16;
+        public const uint32_t DRM_MODE_CONNECTOR_DPI = 17;
+        public const uint32_t DRM_MODE_CONNECTOR_WRITEBACK = 18;
+        public const uint32_t DRM_MODE_CONNECTOR_SPI = 19;
+        public const uint32_t DRM_MODE_CONNECTOR_USB = 20;
+
+        private const int DRM_DISPLAY_MODE_LEN = 32;
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct drmModeModeInfo
+        {
+            public uint32_t clock;
+            public uint16_t hdisplay, hsync_start, hsync_end, htotal, hskew;
+            public uint16_t vdisplay, vsync_start, vsync_end, vtotal, vscan;
+
+            public uint32_t vrefresh;
+
+            public uint32_t flags;
+            public uint32_t type;
+            public fixed byte name[DRM_DISPLAY_MODE_LEN];
+        };
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct drmModeConnector
+        {
+            public uint32_t connector_id;
+            public uint32_t encoder_id; /* Encoder currently connected to */
+            public uint32_t connector_type;
+            public uint32_t connector_type_id;
+            public drmModeConnection connection;
+            public uint32_t mmWidth, mmHeight; /* HxW in millimeters */
+            public drmModeSubPixel subpixel;
+
+            public int count_modes;
+            public drmModeModeInfo* modes;
+
+            public int count_props;
+            public uint32_t *props; /* List of property ids */
+            public uint32_t *prop_values; /* List of property values */
+
+            public int count_encoders;
+            public uint32_t *encoders; /*< List of encoder ids */
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct drmModeCrtc
+        {
+            public uint32_t crtc_id;
+            public uint32_t buffer_id; /* FB id to connect to 0 = disconnect */
+
+            public uint32_t x, y; /* Position on the framebuffer */
+            public uint32_t width, height;
+            public int mode_valid;
+            public drmModeModeInfo mode;
+
+            public int gamma_size; /*< Number of gamma stops */
+        };
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct drmModeEncoder
+        {
+            public uint32_t encoder_id;
+            public uint32_t encoder_type;
+            public uint32_t crtc_id;
+            public uint32_t possible_crtcs;
+            public uint32_t possible_clones;
+        };
+
+        /* drmGetCap() constants */
+        public const uint64_t DRM_CAP_DUMB_BUFFER = 0x1;
+
+        /* Structures for DRM dumb buffer */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct drm_mode_create_dumb
+        {
+            public __u32 height;
+            public __u32 width;
+            public __u32 bpp;
+            public __u32 flags;
+
+            public __u32 handle;
+            public __u32 pitch;
+            public __u64 size;
+        };
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct drm_mode_map_dumb
+        {
+            public __u32 handle;
+            public __u32 pad;
+
+            public __u64 offset;
+        };
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct drm_mode_destroy_dumb
+        {
+            public __u32 handle;
+        };
+    }
+}

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/NativeFbDev.cs
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/NativeFbDev.cs
@@ -1,0 +1,65 @@
+using System.Runtime.InteropServices;
+using __u32 = System.UInt32;
+
+namespace Ab4d.SharpEngine.Samples.LinuxFramebuffer;
+
+public static partial class Native
+{
+    public static unsafe class FbDev
+    {
+        /* ioctl() constants */
+        public const uint FBIOGET_VSCREENINFO = 0x4600;
+        public const uint FBIO_WAITFORVSYNC = 0x40044620;
+
+        /* structures for FBIOGET_VSCREENINFO ioctl */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct fb_bitfield
+        {
+            public __u32 offset; /* beginning of bitfield */
+            public __u32 length; /* length of bitfield */
+            public __u32 msb_right; /* != 0 : Most significant bit is right */
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct fb_var_screeninfo
+        {
+            public __u32 xres; /* visible resolution */
+            public __u32 yres;
+            public __u32 xres_virtual; /* virtual resolution */
+            public __u32 yres_virtual;
+            public __u32 xoffset; /* offset from virtual to visible */
+            public __u32 yoffset; /* resolution */
+
+            public __u32 bits_per_pixel; /* guess what */
+            public __u32 grayscale; /* 0 = color, 1 = grayscale, >1 = FOURCC */
+
+            public fb_bitfield red; /* bitfield in fb mem if true color, */
+            public fb_bitfield green; /* else only length is significant */
+            public fb_bitfield blue;
+            public fb_bitfield transp; /* transparency */
+
+            public __u32 nonstd; /* != 0 Non standard pixel format */
+
+            public __u32 activate; /* see FB_ACTIVATE_* */
+
+            public __u32 height; /* height of picture in mm */
+            public __u32 width; /* width of picture in mm */
+
+            public __u32 accel_flags; /* (OBSOLETE) see fb_info.flags */
+
+            /* Timing: All values in pixclocks, except pixclock (of course) */
+            public __u32 pixclock; /* pixel clock in ps (pico seconds) */
+            public __u32 left_margin; /* time from sync to picture	*/
+            public __u32 right_margin; /* time from picture to sync	*/
+            public __u32 upper_margin; /* time from sync to picture	*/
+            public __u32 lower_margin;
+            public __u32 hsync_len; /* length of horizontal sync */
+            public __u32 vsync_len; /* length of vertical sync */
+            public __u32 sync; /* see FB_SYNC_*	*/
+            public __u32 vmode; /* see FB_VMODE_* */
+            public __u32 rotate; /* angle we rotate counter clockwise */
+            public __u32 colorspace; /* colorspace for FOURCC-based modes */
+            public fixed __u32 reserved[4]; /* Reserved for future compatibility */
+        }
+    }
+}

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/NativeLibInput.cs
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/NativeLibInput.cs
@@ -1,0 +1,165 @@
+using System.Runtime.InteropServices;
+
+using uint32_t = System.UInt32;
+
+namespace Ab4d.SharpEngine.Samples.LinuxFramebuffer;
+
+public static partial class Native
+{
+    public static unsafe class Udev
+    {
+        private const string LibName = "libudev.so.1";
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct udev
+        {
+            /* Opaque struct */
+        }
+
+        /* Functions from libudev */
+        [DllImport(LibName, SetLastError = true)]
+        public static extern udev* udev_new();
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern udev* udev_unref(udev *udev);
+    }
+
+    public static unsafe class LibInput
+    {
+        private const string LibName = "libinput.so.10";
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct libinput
+        {
+            /* Opaque struct */
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int OpenRestrictedCallbackDelegate(string path, int flags, void* user_data);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void CloseRestrictedCallbackDelegate(int fd, void* user_data);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct libinput_event
+        {
+            /* Opaque struct */
+        }
+
+        /* Functions from libinput */
+        [DllImport(LibName, SetLastError = true)]
+        public static extern libinput* libinput_udev_create_context(IntPtr* iface, void* user_data, Udev.udev* udev);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern libinput* libinput_unref(libinput* libinput);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int libinput_udev_assign_seat(libinput* libinput, string seat_id);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int libinput_get_fd(libinput* libinput);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int libinput_dispatch(libinput* libinput);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern libinput_event* libinput_get_event(libinput* libinput);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int libinput_event_get_type(libinput_event* evt);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern void libinput_event_destroy(libinput_event* evt);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern double libinput_event_pointer_get_dx(libinput_event* evt);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern double libinput_event_pointer_get_dy(libinput_event* evt);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern double libinput_event_pointer_get_absolute_x(libinput_event* evt);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern double libinput_event_pointer_get_absolute_x_transformed(libinput_event* evt, uint32_t width);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern double libinput_event_pointer_get_absolute_y(libinput_event* evt);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern double libinput_event_pointer_get_absolute_y_transformed(libinput_event* evt, uint32_t height);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern uint32_t libinput_event_keyboard_get_key(libinput_event* evt);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern uint32_t libinput_event_keyboard_get_key_state(libinput_event* evt);
+
+        /* Event type constants */
+        public const int LIBINPUT_EVENT_KEYBOARD_KEY = 300;
+        public const int LIBINPUT_EVENT_POINTER_MOTION = 400;
+        public const int LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE = 401;
+        public const int LIBINPUT_EVENT_POINTER_BUTTON = 402;
+
+        /* Key state constants */
+        public const int LIBINPUT_KEY_STATE_RELEASED = 0;
+        public const int LIBINPUT_KEY_STATE_PRESSED = 1;
+    }
+
+    public static unsafe class Xkbc
+    {
+        private const string LibName = "libxkbcommon.so.0";
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct xkb_context
+        {
+            /* Opaque struct */
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct xkb_keymap
+        {
+            /* Opaque struct */
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct xkb_rule_names
+        {
+            /* Opaque struct */
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct xkb_state
+        {
+            /* Opaque struct */
+        }
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern xkb_context* xkb_context_new(uint flags);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern void xkb_context_unref(xkb_context* context);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern xkb_keymap* xkb_keymap_new_from_names(xkb_context* context, xkb_rule_names* names, uint flags);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern void xkb_keymap_unref(xkb_keymap* keymap);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern xkb_state* xkb_state_new(xkb_keymap* keymap);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern void xkb_state_unref(xkb_state* state);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern uint xkb_state_update_key(xkb_state* state, uint key, uint direction);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern uint32_t xkb_state_key_get_utf32(xkb_state* state, uint key);
+
+        public const uint XKB_CONTEXT_NO_FLAGS = 0;
+
+        public const uint XKB_KEYMAP_COMPILE_NO_FLAGS = 0;
+    }
+}

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/NativeLibc.cs
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/NativeLibc.cs
@@ -1,0 +1,81 @@
+using System.Runtime.InteropServices;
+
+namespace Ab4d.SharpEngine.Samples.LinuxFramebuffer;
+
+public static partial class Native
+{
+    public static unsafe class LibC
+    {
+        private const string LibName = "libc";
+
+        public const int STDIN_FILENO = 0; /* Standard input. */
+        public const int STDOUT_FILENO = 1; /* Standard output. */
+        public const int STDERR_FILENO = 2; /* Standard error output. */
+
+        /* Structure for poll() */
+        [StructLayout(LayoutKind.Sequential)]
+        public struct pollfd
+        {
+            public int fd;
+            public short events;
+            public short revents;
+        };
+
+        /* Functions from libc */
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int open(string pathname, int flags, int mode);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int close(int fd);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int ioctl(int fd, uint code, void* arg);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern IntPtr mmap(IntPtr addr, IntPtr length, int prot, int flags, int fd, IntPtr offset);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int munmap(IntPtr addr, IntPtr length);
+
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern IntPtr memset(IntPtr addr, int value, IntPtr size);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern int poll(pollfd *fds, IntPtr nfds, int timeout);
+
+        [DllImport(LibName, SetLastError = true)]
+        public static extern string? ttyname(int fd);
+
+        /* open() constants */
+        public const int O_WRONLY = 1;
+        public const int O_RDWR = 2;
+
+        public const int O_NOCTTY = 0x100; /* (00000400 in octal) */
+        public const int O_CLOEXEC = 0x80000; /* set close_on_exec (02000000 in octal) */
+
+        /* mmap() constants */
+        public const int PROT_READ = 1;
+        public const int PROT_WRITE = 2;
+        public const int MAP_SHARED = 1;
+
+        /* poll() constants */
+        public const short POLLIN = 0x0001;
+
+        /* ioctl() constants for TTY mode query/set */
+        public const uint VT_OPENQRY = 0x5600;
+
+        public const uint KDSETMODE = 0x4B3A;
+        public const uint KDGETMODE = 0x4B3B;
+
+        public const uint KDGKBMODE = 0x4B44;
+        public const uint KDSKBMODE = 0x4B45;
+
+        /* Mode constants for KDSETMODE/KDGETMODE */
+        public const uint KD_TEXT = 0x00;
+        public const uint KD_GRAPHICS = 0x01;
+
+        /* Mode constants for KDGKBMODE/KDSKBMODE */
+        public const uint K_OFF = 0x4;
+    }
+}

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/OutputDevice.cs
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/OutputDevice.cs
@@ -1,0 +1,23 @@
+namespace Ab4d.SharpEngine.Samples.LinuxFramebuffer;
+
+public abstract class OutputDevice
+{
+    /// <summary>
+    /// Screen width, in pixels.
+    /// </summary>
+    public int ScreenWidth;
+
+    /// <summary>
+    /// Screen height, in pixels.
+    /// </summary>
+    public int ScreenHeight;
+
+    /// <summary>
+    /// If true, display mode is RGBA, otherwise it is BGRA.
+    /// </summary>
+    public bool RgbaMode;
+
+    public abstract void Initialize(string deviceName, int requestedWidth, int requestedHeight);
+    public abstract unsafe void DisplayImageData(byte *data);
+    public abstract void Cleanup();
+}

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/Program.cs
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/Program.cs
@@ -1,0 +1,561 @@
+﻿using System.CommandLine;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Ab4d.SharpEngine;
+using Ab4d.SharpEngine.Animation;
+using Ab4d.SharpEngine.Cameras;
+using Ab4d.SharpEngine.Common;
+using Ab4d.SharpEngine.Core;
+using Ab4d.SharpEngine.Materials;
+using Ab4d.SharpEngine.SceneNodes;
+using Ab4d.SharpEngine.Vulkan;
+using Ab4d.Vulkan;
+using Microsoft.Extensions.Logging;
+using Logging = Ab4d.SharpEngine.Utilities.Log;
+
+namespace Ab4d.SharpEngine.Samples.LinuxFramebuffer;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        var returnCode = 0;
+
+        /* Prevent attempts at running on unsupported OSes */
+        if (!OperatingSystem.IsLinux())
+        {
+            Console.WriteLine("This sample works only on linux!");
+            return -1;
+        }
+
+        /* Command-line parser */
+        var outputDeviceOption = new Option<FileInfo?>(
+            name: "--output-device",
+            description: "Output framebuffer device (/dev/fbX or /dev/dri/cardX)."
+        );
+        var vulkanDeviceIndexOption = new Option<int>(
+            name: "--vulkan-device-index",
+            description: "Index of Vulkan device used for off-screen rendering."
+        );
+        var drawCursorOption = new Option<bool>(
+            name: "--draw-cursor",
+            description: "Draw mouse cursor.",
+            getDefaultValue: () => true
+        );
+        var widthOption = new Option<int>(
+            name: "--width",
+            description: "Request specified horizontal resolution instead of preferred one."
+        );
+        var heightOption = new Option<int>(
+            name: "--height",
+            description: "Request specified vertical resolution instead of preferred one."
+        );
+        var switchConsoleModeOption = new Option<bool>(
+            name: "--switch-console-mode",
+            description: "Switch console to graphical mode and disable kernel keyboard processing."
+        );
+
+        var rootCommand = new RootCommand("Linux framebuffer demo with off-screen Vulkan renderer.");
+        rootCommand.AddGlobalOption(outputDeviceOption);
+        rootCommand.AddGlobalOption(vulkanDeviceIndexOption);
+        rootCommand.AddGlobalOption(drawCursorOption);
+        rootCommand.AddGlobalOption(widthOption);
+        rootCommand.AddGlobalOption(heightOption);
+        rootCommand.AddGlobalOption(switchConsoleModeOption);
+
+        rootCommand.SetHandler((outputDevice, vulkanDeviceIndex, drawCursor, width, height, switchConsoleMode) =>
+        {
+            /* Set up logging */
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.SetMinimumLevel(LogLevel.Warning)
+                    .AddFilter("Ab4d.SharpEngine.Samples.LinuxFramebuffer", LogLevel.Information)
+                    .AddSimpleConsole(options =>
+                    {
+                        options.SingleLine = true;
+                    });
+            });
+            var logger = loggerFactory.CreateLogger<Program>();
+
+            /* Create program instance and run it */
+            try {
+                var program = new Program(
+                    outputDevice?.FullName,
+                    vulkanDeviceIndex,
+                    drawCursor,
+                    width,
+                    height,
+                    switchConsoleMode,
+                    loggerFactory,
+                    logger);
+                program.ProgramMain();
+                returnCode = 0;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Error during program execution!");
+                returnCode = -1;
+            }
+        }, outputDeviceOption, vulkanDeviceIndexOption, drawCursorOption, widthOption, heightOption, switchConsoleModeOption);
+
+        rootCommand.Invoke(args);
+        return returnCode;
+    }
+
+    /* TTY/VT device setting */
+    private readonly bool _switchConsoleMode;
+
+    private int _vtFd = -1;
+    private bool _kbModeSet;
+    private uint _savedKbMode;
+    private bool _ttyModeSet;
+
+    /* Keyboard and mouse input */
+    private InputDevice? _inputDevice;
+
+    /* Output device */
+    private string? _outputDeviceName;
+
+    private OutputDevice? _outputDevice;
+
+    /* SharpEngine renderer (off-screen) */
+    private readonly int _vulkanDeviceIndex;
+
+    private VulkanDevice? _vulkanDevice;
+    private Scene? _scene;
+    private SceneView? _sceneView;
+
+    private TransformationAnimation? _animation;
+
+    /* Mouse cursor */
+    private readonly bool _drawCursor;
+
+    private readonly int _requestedWidth;
+    private readonly int _requestedHeight;
+
+    /* Main loop */
+    private bool _keepRunning = true;
+
+    /* Logging */
+    private readonly ILoggerFactory? _loggerFactory;
+    private readonly ILogger? _logger;
+
+    private Program(
+        string? outputDeviceName = null,
+        int vulkanDeviceIndex = 0,
+        bool drawCursor = true,
+        int requestedWidth = 0,
+        int requestedHeight = 0,
+        bool switchConsoleMode = false,
+        ILoggerFactory? loggerFactory = null,
+        ILogger? logger = null)
+    {
+        _outputDeviceName = outputDeviceName;
+        _vulkanDeviceIndex = vulkanDeviceIndex;
+        _drawCursor = drawCursor;
+        _requestedWidth = requestedWidth;
+        _requestedHeight = requestedHeight;
+        _switchConsoleMode = switchConsoleMode;
+        _loggerFactory = loggerFactory;
+        _logger = logger;
+    }
+
+    private void ProgramMain()
+    {
+        /* If output device is not explicitly given, try to find one */
+        if (_outputDeviceName == null)
+        {
+            _outputDeviceName = DrmFramebufferOutput.FindFirstDevice() ?? FbDevOutput.FindFirstDevice();
+            if (_outputDeviceName == null)
+            {
+                throw new Exception("Failed to auto-detect output device!");
+            }
+        }
+
+        _logger?.LogInformation("Using output device: {name}", _outputDeviceName);
+
+        /* Setup output device */
+        SetupOutputDevice();
+
+        /* Setup Vulkan device for off-screen rendering */
+        SetupVulkanDevice();
+
+        /* Setup test scene and view */
+        SetupTestSceneAndView();
+
+        /* Allow Ctrl+C to break the main loop - this is useful if program is started remotely via SSH */
+        Console.CancelKeyPress += delegate(object? _, ConsoleCancelEventArgs e) {
+            _logger?.LogInformation("Ctrl+C detected; stopping!");
+            e.Cancel = true;
+            _keepRunning = false;
+        };
+
+        /* Setup keyboard/mouse input */
+        SetupInput();
+
+        /* Put TTY in graphics mode, if necessary */
+        if (_switchConsoleMode) {
+            _logger?.LogInformation("Switching TTY/VT to graphical mode...");
+            try
+            {
+                SetupVirtualTerminal();
+                _logger?.LogInformation("TTY/VT switched to graphical mode!");
+            } catch (Exception e)
+            {
+                _logger?.LogWarning(e, "Failed to switch VT/TTY to graphical mode!");
+            }
+        }
+
+        /* Run main loop */
+        try
+        {
+            MainLoop();
+        }
+        catch (Exception e)
+        {
+            _logger?.LogError(e, "Error during execution of the main loop!");
+        }
+
+        /* Clean-up */
+        RestoreVirtualTerminal();
+        _logger?.LogInformation("Restored TTY/VT to console mode...");
+
+        _outputDevice?.Cleanup();
+        _inputDevice?.Cleanup();
+    }
+
+    private void SetupInput()
+    {
+        Debug.Assert(_outputDevice != null, nameof(_outputDevice) + " != null");
+
+        try
+        {
+            /* Create input handler */
+            _inputDevice = new InputDevice(_outputDevice.ScreenWidth, _outputDevice.ScreenHeight);
+
+            /* Register key-press event handler */
+            _inputDevice.KeyPressEventHandler += (_, args) =>
+            {
+                var keyPressArgs = (InputDevice.KeyPressEventArgs)(args);
+                if (keyPressArgs.KeyCode == 0x1B)
+                {
+                    _logger?.LogInformation("ESC key pressed. Exiting.");
+                    _keepRunning = false;
+                }
+            };
+        }
+        catch (Exception e)
+        {
+            _logger?.LogWarning(e, "Failed to create input device!");
+        }
+    }
+
+    private void SetupOutputDevice()
+    {
+        Debug.Assert(_outputDeviceName != null, nameof(_outputDeviceName) + " != null");
+
+        if (_outputDeviceName.StartsWith("/dev/fb"))
+        {
+            _logger?.LogInformation("Creating FbDev output device: {name}", _outputDeviceName);
+            _outputDevice = new FbDevOutput(_loggerFactory);
+            _outputDevice.Initialize(_outputDeviceName, _requestedWidth, _requestedHeight);
+        } else if (_outputDeviceName.StartsWith("/dev/dri/card")) {
+            _logger?.LogInformation("Creating DRM output device: {name}", _outputDeviceName);
+            _outputDevice = new DrmFramebufferOutput(_loggerFactory);
+            _outputDevice.Initialize(_outputDeviceName, _requestedWidth, _requestedHeight);
+        } else {
+            throw new Exception($"Unsupported device name: {_outputDevice}");
+        }
+    }
+
+    private void SetupVulkanDevice()
+    {
+        /* Create Vulkan instance */
+        var engineCreateOptions = new EngineCreateOptions(
+            applicationName: "LinuxFramebufferDemo",
+            enableStandardValidation: false);
+        var vulkanInstance = new VulkanInstance(engineCreateOptions);
+        _logger?.LogInformation("Vulkan instance created. API version: {version}", vulkanInstance.ApiVersion);
+
+        /* Select Vulkan device */
+        if (vulkanInstance.AllPhysicalDeviceDetails.Length == 0)
+        {
+            throw new Exception("No Vulkan device available!");
+        }
+
+        _logger?.LogInformation("Available Vulkan devices ({count}):", vulkanInstance.AllPhysicalDeviceDetails.Length);
+        for (var i = 0; i < vulkanInstance.AllPhysicalDeviceDetails.Length; i++)
+        {
+            var deviceDetails = vulkanInstance.AllPhysicalDeviceDetails[i];
+            _logger?.LogInformation(" - Device #{number}: {name}", i, deviceDetails.DeviceName);
+        }
+
+        if (_vulkanDeviceIndex >= vulkanInstance.AllPhysicalDeviceDetails.Length)
+        {
+            throw new Exception($"Vulkan device index {_vulkanDeviceIndex} out of range!");
+        }
+
+        _logger?.LogInformation("Selected device #{index}: {name}", _vulkanDeviceIndex, vulkanInstance.AllPhysicalDeviceDetails[_vulkanDeviceIndex].DeviceName);
+
+        _vulkanDevice = new VulkanDevice(
+            vulkanInstance,
+            vulkanInstance.AllPhysicalDeviceDetails[_vulkanDeviceIndex],
+            SurfaceKHR.Null,
+            vulkanInstance.CreateOptions);
+    }
+
+    private void SetupTestSceneAndView()
+    {
+        Debug.Assert(_vulkanDevice != null, nameof(_vulkanDevice) + " != null");
+        Debug.Assert(_outputDevice != null, nameof(_outputDevice) + " != null");
+
+        _scene = new Scene(_vulkanDevice);
+
+        /* Create cube */
+        var boxModelNode = new BoxModelNode(
+            new Vector3(0, 0, 0),
+            new Vector3(25, 25, 25),
+            StandardMaterials.Yellow,
+            "rotatingBox");
+
+        _scene.RootNode.Add(boxModelNode);
+
+        /* Create scene view with dimensions that match screen (framebuffer) resolution */
+        _sceneView = new SceneView(_scene)
+        {
+            Format = _outputDevice.RgbaMode ? StandardBitmapFormats.Rgba : StandardBitmapFormats.Bgra
+        };
+        _sceneView.BackgroundColor = Color4.Black;
+        _sceneView.Camera = new TargetPositionCamera()
+        {
+            TargetPosition = new Vector3(0, 0, 0),
+            Heading = 0,
+            Attitude = -50,
+            Distance = 180,
+        };
+
+        Debug.Assert(_outputDevice.ScreenWidth != 0, "Invalid screen width!");
+        Debug.Assert(_outputDevice.ScreenHeight != 0, "Invalid screen height!");
+        _sceneView.Initialize(_outputDevice.ScreenWidth, height: _outputDevice.ScreenHeight);
+
+        /* Animation */
+        _animation = AnimationBuilder.CreateTransformationAnimation(_scene, "Test animation");
+        _animation.AddTarget(boxModelNode);
+        _animation.Set(TransformationAnimatedProperties.RotateZ, propertyValue: 180, 5000);
+        _animation.Loop = true;
+        _animation.LoopCount = 0; /* Loop forever */
+
+        _animation.Start();
+    }
+
+    private unsafe void DisplayImage(GpuBuffer gpuBuffer, int width, int height)
+    {
+        Debug.Assert(_outputDevice != null, nameof(_outputDevice) + " != null");
+        Debug.Assert(width == _outputDevice.ScreenWidth, $"Image width mismatch: {width} vs {_outputDevice.ScreenWidth}");
+        Debug.Assert(height == _outputDevice.ScreenHeight, $"Image height mismatch: {height} vs {_outputDevice.ScreenHeight}");
+
+        var bufferPtr = gpuBuffer.GetMappedMemoryPtr();
+
+        try
+        {
+            /* Draw mouse cursor */
+            if (_drawCursor && _inputDevice != null)
+            {
+                var (r, g, b) = _outputDevice.RgbaMode ? (255, 0, 0) : (0, 0, 255); /* Red */
+                try
+                {
+                    DrawCursor(
+                        (byte *)bufferPtr,
+                        _outputDevice.ScreenWidth,
+                        _outputDevice.ScreenHeight,
+                        (int)_inputDevice.MousePointerX,
+                        (int)_inputDevice.MousePointerY,
+                        16,
+                        1,
+                        (byte)r,
+                        (byte)g,
+                        (byte)b);
+                }
+                catch (Exception e)
+                {
+                    throw new Exception($"Failed to draw cursor", e);
+                }
+            }
+
+            /* Display on the output device */
+            try
+            {
+                _outputDevice.DisplayImageData((byte *)bufferPtr);
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Failed to write to output device", e);
+
+            }
+        }
+        finally
+        {
+            gpuBuffer.UnmapMemory();
+        }
+
+    }
+    private void MainLoop()
+    {
+        Debug.Assert(_sceneView != null, nameof(_sceneView) + " != null");
+        Debug.Assert(_outputDevice != null, nameof(_outputDevice) + " != null");
+
+        var timer = new Stopwatch();
+        var frameCount = 0;
+
+        timer.Start();
+        while (_keepRunning)
+        {
+            /* Render scene - the callback passed to stagingGpuImageReady takes care of display */
+            _sceneView.RenderToGpuBuffer(
+                preserveGpuImage: true,
+                stagingGpuImageReady: DisplayImage,
+                renderNewFrame: true,
+                format: _sceneView.Format);
+
+            /* FPS estimation */
+            frameCount++;
+            if (timer.ElapsedMilliseconds >= 5000)
+            {
+                var fps = (double)frameCount * 1000 / timer.ElapsedMilliseconds;
+                _logger?.LogInformation("FPS estimate: {fps:F1}", fps);
+                frameCount = 0;
+                timer.Restart();
+            }
+        }
+    }
+
+    private static unsafe void DrawCursor(
+        byte *buffer,
+        int width,
+        int height,
+        int cx,
+        int cy,
+        int size = 32,
+        int thickness = 1,
+        byte r=255,
+        byte g=255,
+        byte b=255)
+    {
+        /* Draw horizontal lines */
+        for (var y = cy - thickness; y <= cy + thickness; y++)
+        {
+            if (y < 0 || y >= height)
+            {
+                continue;
+            }
+
+            for (var x = cx - size; x <= cx + size; x++)
+            {
+                if (x < 0 || x >= width)
+                {
+                    continue;
+                }
+
+                int idx = (y * width + x) * 4;
+                buffer[idx + 0] = r;
+                buffer[idx + 1] = g;
+                buffer[idx + 2] = b;
+                buffer[idx + 3] = 255;
+            }
+        }
+
+        /* Draw vertical lines */
+        for (var x = cx - thickness; x <= cx + thickness; x++)
+        {
+            if (x < 0 || x >= width)
+            {
+                continue;
+            }
+
+            for (var y = cy - size; y <= cy + size; y++)
+            {
+                if (y < 0 || y >= height)
+                {
+                    continue;
+                }
+
+                int idx = (y * width + x) * 4;
+                buffer[idx + 0] = r;
+                buffer[idx + 1] = g;
+                buffer[idx + 2] = b;
+                buffer[idx + 3] = 255;
+            }
+        }
+
+    }
+
+    private unsafe void SetupVirtualTerminal()
+    {
+        var ttyDeviceName = Native.LibC.ttyname(Native.LibC.STDIN_FILENO);
+        if (ttyDeviceName == null || !ttyDeviceName.StartsWith("/dev/tty"))
+        {
+            /* Try to get TTY from $TTYDEVICE environment variable */
+            ttyDeviceName = Environment.GetEnvironmentVariable("TTYDEVICE");
+            if (ttyDeviceName == null)
+            {
+                throw new Exception("Program is not launched from console and TTYDEVICE environment variable is not set!");
+            }
+
+            if (!ttyDeviceName.StartsWith("/dev/tty"))
+            {
+                throw new Exception("Device name given via TTYDEVICE environment variable does not start with /dev/tty!");
+            }
+        }
+        _logger?.LogInformation("Using TTY: {name}", ttyDeviceName);
+
+        _vtFd = Native.LibC.open(ttyDeviceName, Native.LibC.O_RDWR | Native.LibC.O_CLOEXEC | Native.LibC.O_NOCTTY, 0);
+        if (_vtFd < 0)
+        {
+            throw new Exception($"Failed to open TTY device {ttyDeviceName}: {Marshal.GetLastWin32Error()}");
+        }
+
+        /* Completely disable kernel keyboard processing: this prevents us from being killed on Ctrl-C. */
+        uint mode;
+        if (Native.LibC.ioctl(_vtFd, Native.LibC.KDGKBMODE, &mode) < 0)
+        {
+            throw new Exception($"Failed to query keyboard processing mode: {Marshal.GetLastWin32Error()}");
+        }
+        _savedKbMode = mode;
+
+        if (Native.LibC.ioctl(_vtFd, Native.LibC.KDSKBMODE, (void *)(IntPtr)Native.LibC.K_OFF) != 0)
+        {
+            throw new Exception($"Failed to set keyboard processing mode: {Marshal.GetLastWin32Error()}");
+        }
+        _kbModeSet = true;
+
+        /* Change the VT into graphics mode, so the kernel no longer prints text out on top of us. */
+        if (Native.LibC.ioctl(_vtFd, Native.LibC.KDSETMODE, (void *)(IntPtr)Native.LibC.KD_GRAPHICS) != 0) {
+            throw new Exception($"Failed to switch TTY to graphics mode: {Marshal.GetLastWin32Error()}");
+        }
+        _ttyModeSet = true;
+    }
+
+    private unsafe void RestoreVirtualTerminal()
+    {
+        if (_vtFd < 0)
+        {
+            return;
+        }
+
+        /* Restore keyboard processing mode */
+        if (_kbModeSet)
+        {
+            Native.LibC.ioctl(_vtFd, Native.LibC.KDSKBMODE, (void*)_savedKbMode);
+        }
+
+        /* Change the VT into text mode */
+        if (_ttyModeSet)
+        {
+            Native.LibC.ioctl(_vtFd, Native.LibC.KDSETMODE, (void*)Native.LibC.KD_TEXT);
+        }
+
+        Native.LibC.close(_vtFd);
+        _vtFd = -1;
+    }
+}

--- a/Ab4d.SharpEngine.Samples.LinuxFramebuffer/README.md
+++ b/Ab4d.SharpEngine.Samples.LinuxFramebuffer/README.md
@@ -1,0 +1,186 @@
+# Off-screen Vulkan rendering with Linux framebuffer display
+
+This example Linux-specific program demonstrates the use of
+`Ab4d.SharpEngine` with off-screen Vulkan renderer, coupled with
+(separate) display based on the Linux framebuffer device.
+
+The Vulkan renderer can be either hardware (a physical device) or
+software (e.g., a `llvmpipe` software device), and might not directly
+expose any presentation surfaces - and hence cannot be used directly
+for display. The rendered frames are transferred from the renderer
+device, and copied over to the display framebuffer - which can be either
+FbDev (`/dev/fbX`) or based on DRM/KMS (`/dev/dri/cardX`).
+
+Due to the overhead of CPU-based copy between the Vulkan renderer and the
+display framebuffer, this approach is less perfomant than using the Vulkan
+device for rendering and presentation; on the other hand, it allows the
+renderer and display device to be completely de-coupled, and might be an
+attractive choice for applications running on embedded hardware.
+
+For the sake of completeness, we also include a basic keyboard/mouse
+input processing based on `udev` + `libinput`.
+
+
+## Prerequisites
+
+The low-level code in this example program interfaces with the following
+native shared libraries:
+
+* `libc`
+* `libdrm.so.2`
+* `libudev.so.1`
+* `libinput.so.10`
+* `libxkbcommon.so.0`
+
+The last three shared libraries are used for the keyboard/mouse input,
+and may, depending on the environment, need to be installed.
+
+For example, on a Debian/Ubuntu based systems, they can be installed by:
+
+```
+apt install libudev1 libinput10 libxkbcommon0
+```
+
+## Running the program
+
+The program can be ran either locally from console (TTY) or remotely,
+for example from a `ssh` session. In either case, before running the
+program, the system should be switched to console, if necessary (if
+there is a graphical session running, e.g. Xorg or Wayland session).
+This can be done via Ctr+Alt+Fx key (if graphical session is active,
+TTY0 and TTY1 are usually taken, so you should use F3 key).
+
+If the program starts successfully, it should show a spinning yellow
+cube. Its execution can be terminated locally via ESC key (provided the
+keyboard input is working; see subsequent section(s) for more details),
+or, if running remotely, via SIGINT signal (i.e., it can be interrupted
+gracefully from `ssh` session via Ctrl+C, or via `kill -SIGINT`).
+
+The program uses first available Vulkan device for off-screen rendering;
+in case multiple devices are available, a particular one can be selected
+using the `--vulkan-device-index N` command-line option, where `N` is
+the index of the device to use.
+
+The program tries to find first available output device by default,
+preferring the DRM/KMS over the FbDev (see below for details). The first
+available device might not be the correct one; to specify the device to
+use or force specific display backend, use the `--output-device /dev/fbX`
+(for FbDeb) or `--output-device /dev/dri/cardX` (for DRM/KMS) command-line
+switch.
+
+
+## FbDev based display
+
+The legacy FB display uses the FbDev device, called `/dev/fbX`, where
+`X` is a number (typically starting at 0).
+
+Typically, the `/dev/fbX` device is not accessible to user by default.
+If the program exits with `Permission denied` error while trying to
+use FbDev device, you might need to adjust permissions on `/dev/fbX`
+to make it readable/writable by the user (either adjust permissions,
+or change the ownership. as necessary).
+
+When using the FbDev display, the program supports only native
+framebuffer's resolution. Depending on particular driver/implementation,
+there might be no synchronization mechanism available, and using this
+display backend might result in tearing.
+
+Note that even if the program is exited cleanly, the console remains
+displaying the last rendered frame. To clear the display and restore
+the console, use the `clear` command.
+
+
+## DRM/KMS based display
+
+The DRM/KMS offers modern low-level display interface. The program
+implements double-buffered approach, alleviating potential tearing
+issues of the FbDev based display.
+
+The devices used by DRM/KMS are called `/dev/dri/cardX`, and can
+be selected using the `--output-device` command-line switch.
+
+The program attempts to find and use the first connected display
+connector on the device. Currently, there is no option to select a
+particular connector.
+
+By default, the program uses the preferred mode (resolution) of the
+active connector on the device. If multiple modes are supported, a
+different one can be chosen by specifying `--width`  and/or `--height`
+command line switch(es). In this case, the program will attempt to use
+the first mode that matches the specified width and/or height (which
+are in pixels).
+
+
+## Input processing
+
+The program implements basic keyboard event processing; so that it
+can be exited by ESC key being pressed. For demonstration purposes,
+processing of mouse cursor movements is also implemented, with software
+mouse cursor display. The latter is enabled by default, but can be
+disabled using `--show-mouse-cursor false` command-line switch.
+
+The input support requires the corresponding shared libraries (`libudev.so.1`,
+`libinput.so.10`, `libxkbcommon.so.0`) to be available, and requires
+the user to have read/write access to the `/dev/input/*` devices. This
+is typically achieved by ensuring that the user is member of the `input`
+user group.
+
+User not having access to input devices due to insufficient permissions
+will not result in an error, only in lack of input events to be processed.
+
+
+## Console mode switching
+
+When the program is ran, the console remains active in the background,
+and keyboard events are echoed to it. It is therefore possible to
+accidentally type and run a command, or terminate the program by
+pressing Ctrl+C.
+
+To address this, the program can switch the console from text to
+graphical mode (and then restore it back to text mode during clean-up).
+This mode can be enabled using the `--console-mode-switch` command-line
+switch. It is disabled by default, because it disables kernel keyboard
+processing in the console, which means that in the case when program's
+input processing is not working, it may be impossible for user to
+locally exit/terminate the program.
+
+Therefore, it is recommended to first try running the program with
+this option disabled; once you confirm that keyboard input is working
+in the program (i.e., you can exit the program by pressing ESC key
+locally), you can try enabling it.
+
+
+## Tested setup
+
+The example has been developed on and tested against the following setups
+and renderers:
+
+* VirtualBox VM, Fedora 38
+  * llvmpipe (LLVM 16.0.6, 256 bits)
+
+* Dell XPS 15 9560 notebook, Fedora 39 Beta
+  * Intel(R) HD Graphics 630 (KBL GT2)
+  * NVIDIA GeForce GTX 1050
+  * llvmpipe (LLVM 16.0.6, 256 bits)
+
+* Raspberry Pi 4 8GB, Debian 12 Bookworm
+   * V3D 4.2
+   * llvmpipe (LLVM 15.0.6, 128 bits)
+
+
+## Limitations
+
+The example is by no means complete, and aims to demonstrate just the
+basic concepts that should be expanded in the actual application.
+
+The code currently supports only 32-bit depth on display framebuffer
+(B8G8R8A8 or R8G8B8A8, where alpha byte is typically unused). It also
+assumes that the framebuffer's memory is linear and continuous (i.e.,
+that the stride corresponds to display width, without any padding). The
+same assumption is made for the memory layout of the rendered frame
+(as it is copied directly to the framebuffer's memory, instead of
+line-by-line).
+
+The input handling code is also just a skeleton, and does not handle
+mouse button events and modifiers, which would be necessary to implement
+scene manipulation.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following features are supported by the current version:
 **Linux** (including Raspberry PI 4):
   - AvaloniaUI support with SharpEngineSceneView control (Ab4d.SharpEngine.AvaloniaUI library)
   - Using SDL or Glfw (using third-party Silk.Net library; the same project also works on Windows)
+  - Off-screen rendering combined with Linux framebuffer display (FbDev or DRM/KMS).
   - See "Vulkan on Resberry Pi 4" guide on how to use SharpEngine on Resberry Pi 4 with an external monitor.
   
 **Android:**
@@ -124,6 +125,11 @@ The following Visual Studio solutions are available:
   Because Vulkan is not natively supported on macOS and iOS, the MoltenVK library is required to translate the Vulkan calls to Molten API calls.
   See "Building for macOS and iOS" section for more information on how to compile for macOS and iOS.
 
+- **Ab4d.SharpEngine.Samples.LinuxFramebuffer**
+  This solution uses SharpEngine with off-screen Vulkan renderer, and displays
+  the rendered frames on Linux framebuffer display (FbDev or DRM/KMS). See
+  [the example's README](Ab4d.SharpEngine.Samples.LinuxFramebuffer/README.md)
+  for details.
 
 
 ## Quick Start


### PR DESCRIPTION
Add a Linux-specific example that demonstrates the use of `Ab4d.SharpEngine` with off-screen Vulkan renderer, coupled with (separate) display based on the Linux framebuffer device.

Useful in cases when Vulkan renderer is available, but has no presentation surfaces (e.g., llvmpipe software renderer, or a minimal Raspberry Pi setup without graphical session).